### PR TITLE
docs(agents): cursor cloud dev env setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,3 +136,11 @@ The theme in `src/app/globals.css` is the stock `base-nova`/`neutral` palette an
 - **`form` is Radix-only**: The shadcn `form` component depends on `@radix-ui/react-slot` for the `asChild` pattern and has no Base UI variant. For form composition, use `react-hook-form` directly without the shadcn wrapper, or check [basecn.dev](https://basecn.dev) for Base UI ports.
 - **Don't use `shadcn apply`**: It writes files outside `src/components/ui/` (`layout.tsx`, `globals.css`, `lib/utils.ts`, `package.json`) with its own template style, and has a broken dedupe that inserts duplicate imports when quote styles differ.
 - **Preset name mismatch**: `components.json` stores the style as `"base-nova"` (with prefix), but the CLI `init`/`apply` accepts only `nova` (no prefix) with an explicit `--base base` flag.
+
+## Cursor Cloud specific instructions
+
+Single service: the Next.js dev server (`pnpm dev`, http://localhost:3000). No database/backend/external service. Standard commands live in `## Commands` above. The update script keeps deps fresh (`nvm install 24` + `pnpm install`).
+
+- **Node version / PATH gotcha**: the repo requires `node >=24` with `engineStrict: true`, so any `pnpm`/`next` command run under Node 22 fails with `ERR_PNPM_UNSUPPORTED_ENGINE`. The VM ships a `/exec-daemon/node` (v22) pinned at the **front** of `PATH` that `nvm use 24` cannot displace. **Login shells** (`bash -lc '...'`) get Node 24 because `~/.bashrc` explicitly prepends the nvm v24 bin; **non-login** shells (`bash -c`, `sh -c`, many tool runners) silently fall back to v22. Run dev/build/lint/test via a login shell, e.g. `bash -lc 'pnpm dev'`, or first prepend `"$(ls -d "$HOME"/.nvm/versions/node/v24.*/bin | sort -V | tail -1)"` to `PATH`.
+- **`/gallery` is lightbox-first**: there's no grid landing page — the route opens directly into the full-screen photo viewer (arrow keys navigate, a grid/thumbnail toggle is at the bottom). This is intentional, not a rendering bug.
+- **`pnpm build` regenerates the gallery manifest** via the `prebuild` hook (`pnpm gallery` → `src/lib/gallery-manifest.json`); the manifest is committed, so expect a git diff only when `public/gallery/images/` actually changed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
sets up the cloud dev environment for the portfolio site and documents the one non-obvious gotcha found.

## what

- registered an update script (`nvm install 24` + `pnpm install`) so future agents boot with deps ready
- added a `## Cursor Cloud specific instructions` section to `AGENTS.md`

## why the node note matters

the repo needs `node >=24` with `engineStrict: true`. the VM ships `/exec-daemon/node` (v22) pinned at the front of `PATH` that `nvm use 24` can't displace, so non-login shells (`bash -c`, `sh -c`) silently fall back to v22 and any `pnpm`/`next` command dies with `ERR_PNPM_UNSUPPORTED_ENGINE`. login shells (`bash -lc`) get node 24 because `~/.bashrc` prepends the nvm v24 bin. doc note tells future agents to run via a login shell.

## verification

all run on node 24 via login shell against the real app:

- `pnpm install` clean
- `pnpm lint` -> 0 errors (4 pre-existing warnings)
- `pnpm typecheck` clean
- `pnpm build` clean (gallery manifest + `next build`, 81 images)
- `pnpm dev` -> `/` and `/gallery` both 200, full gallery lightbox interaction works end-to-end

[portfolio_gallery_demo.mp4](https://cursor.com/agents/bc-7c18c679-9b49-4629-b81a-b59d41d0b7e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_gallery_demo.mp4)

[homepage](https://cursor.com/agents/bc-7c18c679-9b49-4629-b81a-b59d41d0b7e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[gallery lightbox](https://cursor.com/agents/bc-7c18c679-9b49-4629-b81a-b59d41d0b7e9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgallery_lightbox.webp)

no app code touched — only `AGENTS.md`.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c18c679-9b49-4629-b81a-b59d41d0b7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c18c679-9b49-4629-b81a-b59d41d0b7e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

